### PR TITLE
Report premature system stop as unhealthy

### DIFF
--- a/dropwizard-healthchecks/README.md
+++ b/dropwizard-healthchecks/README.md
@@ -68,6 +68,11 @@ Health monitoring can be stopped to remove the registered health checks in each 
 monitor.stopMonitoring()
 ```
 
+When the actor system stops without the monitoring being stopped first all registered health checks 
+turn unhealthy and indicate the monitored component in an unknown state. This ensures that in case of an 
+unexpected actor system stop (as for example triggered by Eventuate's cassandra extension, when the
+database cannot be accessed at startup) all components are reported as unhealthy.
+
 Healthcheck names
 -----------------
 
@@ -78,7 +83,9 @@ For a given prefix the individual monitors register the following health checks:
   <prefix>.replication-from.<remote-endpoint-id>.<log-name>
   ```
   This turns _unhealthy_ as soon as an `Unavailable` message for this particular log arrives and back 
-  to _healthy_ when a corresponding `Available` message arrives.
+  to _healthy_ when a corresponding `Available` message arrives. See also the 
+  [corresponding section](http://rbmhtechnology.github.io/eventuate/reference/event-log.html#failure-detection)
+  in the Eventuate documentation.
 - `PersistenceHealthMonitor` registers for each local log that uses a circuit breaker:
   ```
   <prefix>.persistence-of.<log-id>

--- a/dropwizard-healthchecks/src/main/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/PersistenceHealthMonitor.scala
+++ b/dropwizard-healthchecks/src/main/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/PersistenceHealthMonitor.scala
@@ -11,6 +11,7 @@ import com.rbmhtechnology.eventuate.log.CircuitBreaker.ServiceNormal
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.AvailabilityMonitor.HealthRegistryName
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.AvailabilityMonitor.UnhealthyCause
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.AvailabilityMonitor.monitorHealth
+import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.StoppableHealthMonitorActor.MonitorActorStoppedPrematurelyException
 
 /**
  * Monitors the connections of the [[ReplicationEndpoint]]
@@ -34,7 +35,7 @@ class PersistenceHealthMonitor(endpoint: ReplicationEndpoint, healthRegistry: He
   }
 
   private val monitorActor =
-    monitorHealth[ServiceNormal, ServiceFailed](endpoint.system, healthRegistry, namePrefix)
+    monitorHealth[ServiceNormal, ServiceFailed](endpoint.system, healthRegistry, UnknownPersistenceStateException, namePrefix)
 
   /**
    * Stop monitoring persistence health and de-register health checks (asynchronously).
@@ -48,4 +49,6 @@ object PersistenceHealthMonitor {
    * for the connection to an [[EventLog]]'s persistence backend is registered.
    */
   def healthName(logId: String): String = s"persistence-of.$logId"
+
+  object UnknownPersistenceStateException extends MonitorActorStoppedPrematurelyException("Persistence")
 }

--- a/dropwizard-healthchecks/src/main/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/StoppableHealthMonitorActor.scala
+++ b/dropwizard-healthchecks/src/main/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/StoppableHealthMonitorActor.scala
@@ -1,0 +1,38 @@
+package com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard
+
+import akka.actor.Actor
+import akka.actor.PoisonPill
+import com.codahale.metrics.health.HealthCheck
+import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.StoppableHealthMonitorActor.StopMonitoring
+
+abstract class StoppableHealthMonitorActor extends Actor {
+
+  private var monitoringStopped = false
+
+  override def postStop(): Unit = {
+    if (!monitoringStopped) monitoringStoppedPrematurely()
+    super.postStop()
+  }
+
+  protected def receiveStop: Receive = {
+    case StopMonitoring =>
+      monitoringStopped = true
+      stopMonitoring()
+      self ! PoisonPill
+  }
+
+  protected def monitoringStoppedPrematurely()
+
+  protected def stopMonitoring(): Unit
+}
+
+object StoppableHealthMonitorActor {
+  case object StopMonitoring
+
+  /**
+   * Exception of an unhealthy [[HealthCheck.Result]] for an unknown health state as the monitoring
+   * system ended prematurely.
+   */
+  abstract class MonitorActorStoppedPrematurelyException(details: String)
+    extends IllegalStateException(s"Monitor actor stopped prematurely. $details has unknown state")
+}

--- a/dropwizard-healthchecks/src/test/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/ActorHealthMonitorSpec.scala
+++ b/dropwizard-healthchecks/src/test/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/ActorHealthMonitorSpec.scala
@@ -3,22 +3,25 @@ package com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard
 import akka.actor.PoisonPill
 import com.codahale.metrics.health.HealthCheck.Result.healthy
 import com.codahale.metrics.health.HealthCheckRegistry
+import com.rbmhtechnology.eventuate.ReplicationEndpoint.DefaultLogName
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.ActorHealthMonitor.AcceptorActorTerminatedException
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.ActorHealthMonitor.EventLogActorTerminatedException
+import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.ActorHealthMonitor.UnknownEventLogActorStateException
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.ActorHealthMonitor.acceptorActorHealthName
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.ActorHealthMonitor.logActorHealthName
 import com.rbmhtechnology.eventuate.tools.test.EventuallyWithDefaultTiming
 import com.rbmhtechnology.eventuate.tools.test.ReplicationEndpoints.withLevelDbReplicationEndpoint
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
+import org.scalatest.concurrent.ScalaFutures
 
-class ActorHealthMonitorSpec extends WordSpec with Matchers with EventuallyWithDefaultTiming {
+class ActorHealthMonitorSpec extends WordSpec with Matchers with EventuallyWithDefaultTiming with ScalaFutures {
 
   import ActorHealthMonitorSpec._
 
   "ActorMonitor" when {
     "all EventLog actors are up" must {
-      "Report healthy for each" in {
+      "report healthy for each" in {
         withLevelDbReplicationEndpoint(LogNames) { endpoint =>
           val healthRegistry = new HealthCheckRegistry()
           new ActorHealthMonitor(endpoint, healthRegistry)
@@ -31,7 +34,7 @@ class ActorHealthMonitorSpec extends WordSpec with Matchers with EventuallyWithD
       }
     }
     "an EventLog actors terminate" must {
-      "Report unhealthy for that and healthy for all others" in {
+      "report unhealthy for that and healthy for all others" in {
         withLevelDbReplicationEndpoint(LogNames) { endpoint =>
           val healthRegistry = new HealthCheckRegistry()
           new ActorHealthMonitor(endpoint, healthRegistry)
@@ -44,7 +47,7 @@ class ActorHealthMonitorSpec extends WordSpec with Matchers with EventuallyWithD
       }
     }
     "the Acceptor actor is up" must {
-      "Report healthy for that" in {
+      "report healthy for that" in {
         withLevelDbReplicationEndpoint() { endpoint =>
           val healthRegistry = new HealthCheckRegistry()
           new ActorHealthMonitor(endpoint, healthRegistry)
@@ -55,7 +58,7 @@ class ActorHealthMonitorSpec extends WordSpec with Matchers with EventuallyWithD
       }
     }
     "the Acceptor actor terminates" must {
-      "Report unhealthy for that" in {
+      "report unhealthy for that" in {
         withLevelDbReplicationEndpoint() { endpoint =>
           val healthRegistry = new HealthCheckRegistry()
           new ActorHealthMonitor(endpoint, healthRegistry)

--- a/dropwizard-healthchecks/src/test/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/ReplicationEndpointHealthMonitorSpec.scala
+++ b/dropwizard-healthchecks/src/test/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/ReplicationEndpointHealthMonitorSpec.scala
@@ -1,25 +1,28 @@
 package com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard
 
 import com.codahale.metrics.health.HealthCheckRegistry
+import com.rbmhtechnology.eventuate.ReplicationEndpoint
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.HealthCheckRegistries.optionallyPrefixed
 import com.rbmhtechnology.eventuate.tools.test.EventuallyWithDefaultTiming
 import com.rbmhtechnology.eventuate.tools.test.ReplicationEndpoints.withBidirectionalReplicationEndpoints
+import org.scalatest.Inspectors
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
+import org.scalatest.concurrent.ScalaFutures
 
 import scala.collection.JavaConverters._
 
-class ReplicationEndpointHealthMonitorSpec extends WordSpec with Matchers with EventuallyWithDefaultTiming {
+class ReplicationEndpointHealthMonitorSpec extends WordSpec with Matchers with EventuallyWithDefaultTiming with ScalaFutures with Inspectors {
 
-  "ReplicationEndpointHealthMonitorSpec.stopMonitoring" must {
+  import ReplicationEndpointHealthMonitorSpec._
+
+  "ReplicationEndpointHealthMonitor.stopMonitoring" must {
     "de-register all health checks" in withBidirectionalReplicationEndpoints() { (monitoredEndpoint, remoteEndpoint) =>
       val healthRegistry = new HealthCheckRegistry
       val prefix = Some("prefix")
       val monitor = new ReplicationEndpointHealthMonitor(monitoredEndpoint, healthRegistry, prefix)
 
-      val expectedHealthNames = monitoredEndpoint.logNames.flatMap { logName =>
-        Set(ReplicationHealthMonitor.healthName(remoteEndpoint.id, logName), ActorHealthMonitor.logActorHealthName(monitoredEndpoint.logId(logName)))
-      } + ActorHealthMonitor.acceptorActorHealthName
+      val expectedHealthNames = actorHealthNames(monitoredEndpoint) ++ replicationHealthNames(remoteEndpoint)
       eventually {
         healthRegistry.getNames.asScala shouldBe expectedHealthNames.map(optionallyPrefixed(_, prefix))
       }
@@ -31,4 +34,35 @@ class ReplicationEndpointHealthMonitorSpec extends WordSpec with Matchers with E
       }
     }
   }
+  "ReplicationEndpointHealthMonitor" when {
+    "ActorSystem stopps prematurely" must {
+      "report unhealthy for all monitored items" in withBidirectionalReplicationEndpoints() { (monitoredEndpoint, remoteEndpoint) =>
+        val healthRegistry = new HealthCheckRegistry
+        val monitor = new ReplicationEndpointHealthMonitor(monitoredEndpoint, healthRegistry)
+
+        val expectedHealthNames = actorHealthNames(monitoredEndpoint) ++ replicationHealthNames(remoteEndpoint)
+        eventually {
+          healthRegistry.getNames.asScala shouldBe expectedHealthNames
+        }
+
+        whenReady(monitoredEndpoint.system.terminate()) { _ =>
+          eventually {
+            healthRegistry.getNames.asScala shouldBe expectedHealthNames
+            forAll(healthRegistry.runHealthChecks().asScala) {
+              case (_, result) =>
+                result shouldNot be('isHealthy)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+object ReplicationEndpointHealthMonitorSpec {
+  def actorHealthNames(endpoint: ReplicationEndpoint): Set[String] =
+    endpoint.logNames.map(logName => ActorHealthMonitor.logActorHealthName(endpoint.logId(logName))) + ActorHealthMonitor.acceptorActorHealthName
+
+  def replicationHealthNames(endpoint: ReplicationEndpoint): Set[String] =
+    endpoint.logNames.map(logName => ReplicationHealthMonitor.healthName(endpoint.id, logName))
 }

--- a/test-core/src/test/scala/com/rbmhtechnology/eventuate/tools/test/AkkaSystems.scala
+++ b/test-core/src/test/scala/com/rbmhtechnology/eventuate/tools/test/AkkaSystems.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import akka.actor.ActorSystem
 import akka.actor.Address
 import akka.actor.ExtendedActorSystem
+import com.rbmhtechnology.eventuate.ReplicationConnection.DefaultRemoteSystemName
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -37,7 +38,7 @@ object AkkaSystems {
     }
   }
 
-  def newUniqueSystemName: String = s"default${akkaSystemCounter.getAndIncrement()}"
+  def newUniqueSystemName: String = s"$DefaultRemoteSystemName${akkaSystemCounter.getAndIncrement()}"
 
   def akkaAddress(system: ActorSystem): Address = system match {
     case sys: ExtendedActorSystem => sys.provider.getDefaultAddress


### PR DESCRIPTION
If an monitor-actor ist stopped (e.g. by stopping the ActorSystem)
without having sent a StopMonitoring first all monitored components are
reported as unhealthy.
- closes #22
