### PR TITLE
Upgrade kamon-core to 0.6.5 to enable full 2.12 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
 script:
-  - if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then kamon_tasks="kamon-metrics/test kamon-metrics/package"; else kamon_tasks=""; fi && sbt ++$TRAVIS_SCALA_VERSION test package universal:packageBin $kamon_tasks
+  - sbt ++$TRAVIS_SCALA_VERSION test package universal:packageBin
   - find $HOME/.sbt -name "*.lock" -exec rm {} +
   - find $HOME/.ivy2 -name "ivydata-*.properties" -exec rm {} +
 after_success:
-  - if [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_BRANCH" = master -o -n "$TRAVIS_TAG" ]; then if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then kamon_tasks="kamon/publish"; else kamon_tasks=""; fi && sbt ++$TRAVIS_SCALA_VERSION publish $kamon_tasks; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_BRANCH" = master -o -n "$TRAVIS_TAG" ]; then sbt ++$TRAVIS_SCALA_VERSION publish fi
 scala:
   - 2.11.8
-  - 2.12.0
+  - 2.12.1
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ This repository contains tools that support operating
 - [Dropwizard health checks](dropwizard-healthchecks/README.md): A library providing health checks for
   an replication endpoint based on 
   [dropwizard's health check lib](http://metrics.dropwizard.io/3.1.0/getting-started/#health-checks)
+  
+All libraries are available for scala 2.11 and 2.12.

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,6 @@ lazy val dropwizardMetrics = subProject("dropwizard-metrics").dependsOn(testCore
 lazy val kamonMetrics = subProject("kamon-metrics").dependsOn(testCore % "test->test")
 lazy val dropwizardHealth = subProject("dropwizard-healthchecks").dependsOn(testCore % "test->test")
 
-// exclude kamon by default as there is no scala 2.12 build yet
-lazy val root = (project in file(".")).aggregate(testCore, logViewer, dropwizardMetrics, dropwizardHealth)
-
 // release
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/kamon-metrics/README.md
+++ b/kamon-metrics/README.md
@@ -26,8 +26,6 @@ resolvers += "OJO Releases" at "https://oss.jfrog.org/oss-release-local"
 
 ```
 
-Note that there is no scala 2.12 build available for this module as it depends on `kamon-core` and 
-there is no scala 2.12 build available for `kamon-core` yet.
 
 Start/Stop recording metrics
 ----------------------------

--- a/kamon-metrics/build.sbt
+++ b/kamon-metrics/build.sbt
@@ -1,1 +1,1 @@
-libraryDependencies += "io.kamon" %% "kamon-core" % "0.6.3"
+libraryDependencies += "io.kamon" %% "kamon-core" % "0.6.5"


### PR DESCRIPTION
As there is a scala 2.12 build available for kamon-core 0.6.5, the
kamon-metrics lib is no longer excluded from the 2.12 build.

Closes #28