### PR TITLE
Allow reporting replication as unhealthy initially

### DIFF
--- a/dropwizard-healthchecks/README.md
+++ b/dropwizard-healthchecks/README.md
@@ -1,8 +1,8 @@
-Eventuate replication endpoint health information for dropwizard's healthchecks lib
+Eventuate replication endpoint health information for dropwizard's health-checks lib
 ===================================================================================
 
 eventuate-tool's dropwizard-healthchecks provides health monitoring facilities for Eventuate components based on 
-[dropwizard's healthchecks library](http://metrics.dropwizard.io/3.1.0/getting-started/#health-checks).
+[dropwizard's health-checks library](http://metrics.dropwizard.io/3.1.0/getting-started/#health-checks).
 The following can be monitored:
 
 - health of the replication from remote source logs based on 
@@ -73,7 +73,16 @@ turn unhealthy and indicate the monitored component in an unknown state. This en
 unexpected actor system stop (as for example triggered by Eventuate's cassandra extension, when the
 database cannot be accessed at startup) all components are reported as unhealthy.
 
-Healthcheck names
+By default the `ReplicationHealthMonitor` does not report the health status for the replication from remote logs where 
+the connection could not yet be established as the health monitoring is based on Eventuate's 
+`Available` and `Unavailable` notifications that are only sent if an initial connect was successful.
+The `ReplicationHealthMonitor` can be initialized with an 
+optional parameter `initiallyUnhealty` that takes a set of log-ids of remote logs whose replication status
+shall be reported as unhealthy initially (because the connection can not be established) until 
+the first `Available` is received. As Eventuate internally does not know the endpoint ids of remote 
+endpoints until the connection is established the ids have to be provided explicitly.
+
+Health-check names
 -----------------
 
 For a given prefix the individual monitors register the following health checks:

--- a/dropwizard-healthchecks/src/test/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/ReplicationHealthMonitorSpec.scala
+++ b/dropwizard-healthchecks/src/test/scala/com/rbmhtechnology/eventuate/tools/healthcheck/dropwizard/ReplicationHealthMonitorSpec.scala
@@ -4,9 +4,16 @@ import akka.actor.Props
 import com.codahale.metrics.health.HealthCheck.Result
 import com.codahale.metrics.health.HealthCheckRegistry
 import com.rbmhtechnology.eventuate.Acceptor
+import com.rbmhtechnology.eventuate.ReplicationEndpoint.DefaultLogName
+import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.ReplicationHealthMonitor.ReplicationConnectionNotYetEstablishedException
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.ReplicationHealthMonitor.ReplicationUnhealthyException
 import com.rbmhtechnology.eventuate.tools.healthcheck.dropwizard.ReplicationHealthMonitor.healthName
+import com.rbmhtechnology.eventuate.tools.test.AkkaSystems.akkaRemotingConfig
+import com.rbmhtechnology.eventuate.tools.test.AkkaSystems.withActorSystems
+import com.rbmhtechnology.eventuate.tools.test.EventLogs.withLevelDbLogConfigs
 import com.rbmhtechnology.eventuate.tools.test.EventuallyWithDefaultTiming
+import com.rbmhtechnology.eventuate.tools.test.ReplicationEndpoints.replicationConnectionFor
+import com.rbmhtechnology.eventuate.tools.test.ReplicationEndpoints.replicationEndpoint
 import com.rbmhtechnology.eventuate.tools.test.ReplicationEndpoints.withBidirectionalReplicationEndpoints
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
@@ -42,6 +49,29 @@ class ReplicationHealthMonitorSpec extends WordSpec with Matchers with Eventuall
                 healthRegistry.runHealthCheck(healthName(remoteEndpoint.id, logName)) shouldBe Result.healthy()
               }
             }
+        }
+    }
+    "no replication connection can be established to a remote log" must {
+      "report the replication connection as unhealthy until is it established" in
+        withLevelDbLogConfigs(2) { configs =>
+          withActorSystems(configs.map(_.withFallback(akkaRemotingConfig))) {
+            case Seq(systemA, systemB) =>
+              val connectionToA = replicationConnectionFor(systemA)
+              val connectionToB = replicationConnectionFor(systemB)
+              val endpointA = replicationEndpoint(connections = Set(connectionToB))(systemA)
+              val healthRegistry = new HealthCheckRegistry()
+              val endpointBId = systemB.name
+
+              new ReplicationHealthMonitor(endpointA, healthRegistry, initiallyUnhealthy = Set(LogId(endpointBId, DefaultLogName)))
+              eventually {
+                val healthStatus = healthRegistry.runHealthCheck(healthName(endpointBId, DefaultLogName))
+                healthStatus.getError shouldBe a[ReplicationConnectionNotYetEstablishedException]
+              }
+              val endpointB = replicationEndpoint(connections = Set(connectionToA))(systemB)
+              eventually {
+                healthRegistry.runHealthCheck(healthName(endpointBId, DefaultLogName)) shouldBe Result.healthy()
+              }
+          }
         }
     }
   }


### PR DESCRIPTION
Replication health reporting is based on Eventuate's
Available/Unavailable messages. However those are not sent when a
connection to a remote endpoint cannot be established at all (the ids
of these log respectively the corresponding endpoint is not known
until after a successful connect).

Now the ReplicationHealthMonitor can take an optional set of log-ids
for logs whose replication status shall be reported as unhealthy,
if the initial connection cannot be established.

Closes #25